### PR TITLE
Add portfolio analytics toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# Hello-World
-About Time I Get Started
+# Portfolio Analytics Application
+
+This repository provides a reference implementation of a professional-grade
+Python toolkit for financial portfolio analytics, optimisation and technical
+analysis. Key features include:
+
+* **Data ingestion** – load holdings from an Excel file and retrieve
+  historical market data via Bloomberg using the `xbbg` library.
+* **Analytics** – calculate performance (Sharpe, alpha, beta), risk metrics
+  (VaR, CVaR, volatility) and basic asset allocation breakdowns.
+* **Backtesting** – run simple backtests using `bt`, `vectorbt` or
+  `backtrader`.
+* **Technical analysis** – compute RSI, MACD, Bollinger Bands and moving
+  averages using `TA-Lib` and generate naïve trading signals.
+* **Optimisation** – optimise portfolio weights with multiple objectives
+  (maximise return, minimise risk, maximise Sharpe ratio) using `cvxpy`.
+* **Visualisation** – produce performance charts, risk/return scatter plots,
+  allocation pie charts and technical indicator overlays with `matplotlib`.
+* **Interactive dashboard** – a `Streamlit` application (`dashboard.py`) allows
+  uploading of Excel portfolios, selection of indicators and optimisation
+  objectives, viewing of analytics and charts and exporting of results.
+
+## Getting started
+
+```bash
+pip install -r requirements.txt
+streamlit run dashboard.py
+```
+
+The dashboard guides you through uploading a portfolio, fetching data,
+performing analytics and viewing optimisation results.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,44 @@
+"""Streamlit dashboard for portfolio analytics."""
+
+from __future__ import annotations
+
+import io
+import pandas as pd
+import streamlit as st
+
+from portfolio_app import data_ingestion, analytics, technical, optimization, visualization
+
+
+st.title("Portfolio Analytics Dashboard")
+
+uploaded_file = st.file_uploader("Upload portfolio Excel", type=["xls", "xlsx"])
+if uploaded_file:
+    portfolio = data_ingestion.load_portfolio_from_excel(io.BytesIO(uploaded_file.read()))
+    st.write("Holdings", portfolio)
+
+    tickers = portfolio['Ticker'].tolist()
+    start = st.date_input("Start Date")
+    end = st.date_input("End Date")
+    if start and end:
+        prices = data_ingestion.fetch_price_history(tickers, start, end)
+        st.line_chart(prices)
+
+        returns = prices.pct_change().dropna()
+        metrics = analytics.compute_performance_metrics(returns.mean(axis=1))
+        st.write("Performance", metrics)
+        risks = analytics.compute_risk_metrics(returns.mean(axis=1))
+        st.write("Risk", risks)
+
+        indicators = technical.calculate_indicators(prices.iloc[:, 0])
+        signals = technical.generate_signals(indicators)
+        st.write("Signals", signals.tail())
+
+        objective = st.selectbox("Optimization objective", ['return', 'risk', 'sharpe'])
+        exp_ret = returns.mean() * 252
+        cov = returns.cov() * 252
+        weights = optimization.optimise_portfolio(exp_ret, cov, objective)
+        st.write("Optimized Weights", weights)
+
+        if st.button("Plot Allocation"):
+            visualization.plot_allocation(weights)
+            st.pyplot()

--- a/portfolio_app/__init__.py
+++ b/portfolio_app/__init__.py
@@ -1,0 +1,11 @@
+"""Portfolio analytics package."""
+
+from . import data_ingestion, analytics, technical, optimization, visualization
+
+__all__ = [
+    'data_ingestion',
+    'analytics',
+    'technical',
+    'optimization',
+    'visualization',
+]

--- a/portfolio_app/analytics.py
+++ b/portfolio_app/analytics.py
@@ -1,0 +1,111 @@
+"""Portfolio analytics and backtesting utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class PerformanceMetrics:
+    """Container for common performance metrics."""
+
+    sharpe: float
+    alpha: float
+    beta: float
+
+
+@dataclass
+class RiskMetrics:
+    """Container for risk related metrics."""
+
+    var: float
+    cvar: float
+    volatility: float
+
+
+def compute_performance_metrics(portfolio_returns: pd.Series,
+                                benchmark_returns: Optional[pd.Series] = None,
+                                risk_free_rate: float = 0.0,
+                                periods_per_year: int = 252) -> PerformanceMetrics:
+    """Compute Sharpe ratio, alpha and beta of a return series."""
+    excess_returns = portfolio_returns - risk_free_rate / periods_per_year
+    sharpe = np.sqrt(periods_per_year) * excess_returns.mean() / excess_returns.std()
+
+    if benchmark_returns is None:
+        alpha = np.nan
+        beta = np.nan
+    else:
+        cov = np.cov(portfolio_returns, benchmark_returns)
+        beta = cov[0, 1] / cov[1, 1]
+        alpha = (portfolio_returns.mean() - beta * benchmark_returns.mean()) * periods_per_year
+    return PerformanceMetrics(sharpe=sharpe, alpha=alpha, beta=beta)
+
+
+def compute_risk_metrics(portfolio_returns: pd.Series,
+                         confidence: float = 0.95) -> RiskMetrics:
+    """Compute VaR, CVaR and annualized volatility."""
+    sorted_returns = np.sort(portfolio_returns)
+    index = int((1 - confidence) * len(sorted_returns))
+    var = -sorted_returns[index]
+    cvar = -sorted_returns[:index].mean()
+    volatility = np.sqrt(252) * portfolio_returns.std()
+    return RiskMetrics(var=var, cvar=cvar, volatility=volatility)
+
+
+def asset_allocation_breakdown(portfolio: pd.DataFrame) -> pd.Series:
+    """Return weights of each asset based on market value."""
+    value = portfolio['Shares'] * portfolio.get('Price', 1)
+    weights = value / value.sum()
+    return weights
+
+
+def backtest_portfolio(prices: pd.DataFrame,
+                       signals: Optional[pd.DataFrame] = None,
+                       engine: str = 'bt'):
+    """Backtest a portfolio using the specified engine.
+
+    Parameters
+    ----------
+    prices : pandas.DataFrame
+        Price history of assets.
+    signals : pandas.DataFrame, optional
+        Trading signals indexed like ``prices``.
+    engine : {'bt', 'vectorbt', 'backtrader'}
+        Backend to use for the backtest. Only basic examples are provided.
+    """
+    engine = engine.lower()
+    if engine == 'bt':
+        try:
+            import bt
+        except ImportError as exc:  # pragma: no cover - library optional
+            raise ImportError("bt library is required for this backtest") from exc
+        strategy = bt.Strategy('portfolio', [bt.algos.RunOnDate(prices.index[0]),
+                                             bt.algos.SelectAll(),
+                                             bt.algos.WeighEqually(),
+                                             bt.algos.Rebalance()])
+        test = bt.Backtest(strategy, prices)
+        return bt.run(test)
+    elif engine == 'vectorbt':
+        try:
+            import vectorbt as vbt
+        except ImportError as exc:  # pragma: no cover - library optional
+            raise ImportError("vectorbt is required for this backtest") from exc
+        pf = vbt.Portfolio.from_signals(prices, entries=signals > 0, exits=signals < 0)
+        return pf.stats()
+    elif engine == 'backtrader':
+        try:
+            import backtrader as bttr
+        except ImportError as exc:  # pragma: no cover - library optional
+            raise ImportError("backtrader is required for this backtest") from exc
+        # Minimal backtrader example
+        cerebro = bttr.Cerebro()
+        data_feed = bttr.feeds.PandasData(dataname=prices)
+        cerebro.adddata(data_feed)
+        cerebro.addstrategy(bttr.Strategy)
+        result = cerebro.run()
+        return result
+    else:
+        raise ValueError(f"Unknown engine: {engine}")

--- a/portfolio_app/data_ingestion.py
+++ b/portfolio_app/data_ingestion.py
@@ -1,0 +1,45 @@
+"""Data ingestion utilities for portfolio analytics."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def load_portfolio_from_excel(path: str) -> pd.DataFrame:
+    """Load portfolio holdings from an Excel file.
+
+    The Excel file should contain at least two columns: ``Ticker`` and
+    ``Shares``. Additional columns are ignored but preserved in the returned
+    :class:`~pandas.DataFrame` for potential use (e.g. sector classification).
+    """
+    df = pd.read_excel(path)
+    return df
+
+
+def fetch_price_history(tickers, start, end):
+    """Fetch historical price data using Bloomberg via :mod:`xbbg`.
+
+    Parameters
+    ----------
+    tickers : sequence of str
+        Bloomberg tickers to request.
+    start : str or datetime-like
+        Start date for data retrieval.
+    end : str or datetime-like
+        End date for data retrieval.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Historical close prices indexed by date with tickers in columns.
+    """
+    try:
+        from xbbg import blp
+    except ImportError as exc:  # pragma: no cover - library optional
+        raise ImportError("xbbg is required for Bloomberg data retrieval") from exc
+
+    data = blp.bdh(tickers, "PX_LAST", start_date=start, end_date=end)
+    # xbbg returns a multi-index; we only keep the price level
+    if isinstance(data.columns, pd.MultiIndex):
+        data = data.xs("PX_LAST", level=1, axis=1)
+    return data

--- a/portfolio_app/optimization.py
+++ b/portfolio_app/optimization.py
@@ -1,0 +1,56 @@
+"""Portfolio optimisation utilities using cvxpy."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def optimise_portfolio(expected_returns: pd.Series,
+                        cov: pd.DataFrame,
+                        objective: str = 'sharpe',
+                        max_weight: float = 1.0,
+                        sector_limits: dict | None = None) -> pd.Series:
+    """Optimize portfolio weights using :mod:`cvxpy`.
+
+    Parameters
+    ----------
+    expected_returns : pandas.Series
+        Expected annual returns for each asset.
+    cov : pandas.DataFrame
+        Covariance matrix of asset returns.
+    objective : {'return', 'risk', 'sharpe'}
+        Optimisation objective.
+    max_weight : float, optional
+        Maximum allocation per asset.
+    sector_limits : dict, optional
+        Mapping of sector name to maximum total weight for that sector.
+    """
+    import cvxpy as cp
+
+    n = len(expected_returns)
+    w = cp.Variable(n)
+    ret = expected_returns.values @ w
+    risk = cp.quad_form(w, cov.values)
+
+    constraints = [cp.sum(w) == 1, w >= 0, w <= max_weight]
+
+    if sector_limits:
+        for sector, limit in sector_limits.items():
+            if sector in expected_returns.index.names:
+                mask = expected_returns.index.get_level_values('sector') == sector
+                constraints.append(cp.sum(w[mask]) <= limit)
+
+    if objective == 'return':
+        prob = cp.Problem(cp.Maximize(ret), constraints)
+    elif objective == 'risk':
+        prob = cp.Problem(cp.Minimize(risk), constraints)
+    elif objective == 'sharpe':
+        gamma = cp.Parameter(nonneg=True)
+        prob = cp.Problem(cp.Maximize(ret - gamma * risk), constraints)
+        gamma.value = 1
+    else:
+        raise ValueError("Unknown objective")
+
+    prob.solve()
+    return pd.Series(w.value, index=expected_returns.index, name='weight')

--- a/portfolio_app/technical.py
+++ b/portfolio_app/technical.py
@@ -1,0 +1,52 @@
+"""Technical analysis helpers using TA-Lib."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def calculate_indicators(prices: pd.Series, indicators: list[str] | None = None) -> pd.DataFrame:
+    """Calculate technical indicators using :mod:`TA-Lib`.
+
+    Parameters
+    ----------
+    prices : pandas.Series
+        Price series to analyse.
+    indicators : list of str, optional
+        Indicators to compute. Supported values: ``rsi``, ``macd``, ``bollinger``,
+        ``sma`` and ``ema``. If ``None`` all are calculated.
+    """
+    try:
+        import talib
+    except ImportError as exc:  # pragma: no cover - library optional
+        raise ImportError("TA-Lib is required for technical analysis") from exc
+
+    if indicators is None:
+        indicators = ['rsi', 'macd', 'bollinger', 'sma', 'ema']
+
+    out = pd.DataFrame(index=prices.index)
+    if 'rsi' in indicators:
+        out['rsi'] = talib.RSI(prices)
+    if 'macd' in indicators:
+        macd, macdsignal, macdhist = talib.MACD(prices)
+        out['macd'] = macd
+        out['macdsignal'] = macdsignal
+    if 'bollinger' in indicators:
+        upper, middle, lower = talib.BBANDS(prices)
+        out['bb_upper'] = upper
+        out['bb_middle'] = middle
+        out['bb_lower'] = lower
+    if 'sma' in indicators:
+        out['sma'] = talib.SMA(prices)
+    if 'ema' in indicators:
+        out['ema'] = talib.EMA(prices)
+    return out
+
+
+def generate_signals(indicators: pd.DataFrame) -> pd.Series:
+    """Generate simplistic trading signals from indicators."""
+    signal = pd.Series(0, index=indicators.index)
+    if 'rsi' in indicators:
+        signal[indicators['rsi'] < 30] = 1
+        signal[indicators['rsi'] > 70] = -1
+    return signal

--- a/portfolio_app/visualization.py
+++ b/portfolio_app/visualization.py
@@ -1,0 +1,54 @@
+"""Plotting helpers for portfolio analytics."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def plot_performance(portfolio: pd.Series, benchmark: pd.Series | None = None):
+    """Plot cumulative performance of the portfolio and optionally a benchmark."""
+    cum = (1 + portfolio).cumprod()
+    plt.figure(figsize=(10, 4))
+    plt.plot(cum, label='Portfolio')
+    if benchmark is not None:
+        plt.plot((1 + benchmark).cumprod(), label='Benchmark')
+    plt.legend()
+    plt.title('Cumulative Performance')
+    plt.tight_layout()
+
+
+def plot_risk_return(portfolio_metrics: pd.DataFrame):
+    """Scatter plot of risk vs return for a set of portfolios."""
+    plt.figure(figsize=(6, 4))
+    plt.scatter(portfolio_metrics['volatility'], portfolio_metrics['return'])
+    for i, txt in enumerate(portfolio_metrics.index):
+        plt.annotate(txt, (portfolio_metrics['volatility'][i], portfolio_metrics['return'][i]))
+    plt.xlabel('Volatility')
+    plt.ylabel('Return')
+    plt.title('Risk-Return Profile')
+    plt.tight_layout()
+
+
+def plot_allocation(weights: pd.Series):
+    """Pie chart of portfolio allocation."""
+    plt.figure(figsize=(6, 6))
+    weights.plot.pie(autopct='%1.1f%%')
+    plt.title('Asset Allocation')
+    plt.ylabel('')
+    plt.tight_layout()
+
+
+def plot_technical(prices: pd.Series, indicators: pd.DataFrame):
+    """Overlay technical indicators on price."""
+    plt.figure(figsize=(10, 4))
+    plt.plot(prices, label='Price')
+    if 'sma' in indicators:
+        plt.plot(indicators['sma'], label='SMA')
+    if 'ema' in indicators:
+        plt.plot(indicators['ema'], label='EMA')
+    if 'bb_upper' in indicators:
+        plt.fill_between(prices.index, indicators['bb_lower'], indicators['bb_upper'], color='grey', alpha=0.3)
+    plt.legend()
+    plt.title('Technical Indicators')
+    plt.tight_layout()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+numpy
+pandas
+cvxpy
+matplotlib
+scipy
+scikit-learn
+xbbg
+TA-Lib
+bt
+vectorbt
+backtrader
+streamlit


### PR DESCRIPTION
## Summary
- Implement data ingestion using pandas and Bloomberg via xbbg
- Add analytics module for performance, risk, allocation and backtesting
- Integrate technical analysis, optimization, visualization and Streamlit dashboard

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6894f1d9275083299219e6e225b7876e